### PR TITLE
update:InputFileItemCircularImageコンポーネントのprops名を変更

### DIFF
--- a/src/resources/js/Molecules/InputFileItemCircularImage.vue
+++ b/src/resources/js/Molecules/InputFileItemCircularImage.vue
@@ -11,7 +11,7 @@ const props = defineProps({
     type: String,
     required: true,
   },
-  optionalIconIsShown: {
+  isShowOptionalIcon: {
     type: Boolean,
     default: false,
   },
@@ -47,7 +47,7 @@ const onFileCanceled = () => {
   <div>
     <div class="flex items-baseline">
       <VLabel class="mb-1 mr-1">{{ label }}</VLabel>
-      <OptionalIcon v-if="optionalIconIsShown" />
+      <OptionalIcon v-if="isShowOptionalIcon" />
     </div>
     <div class="flex items-center">
       <CircularImage :alt="alt" :src="src" class="mr-8"/>

--- a/src/resources/js/Organisms/UserRegisterForm.vue
+++ b/src/resources/js/Organisms/UserRegisterForm.vue
@@ -75,7 +75,7 @@ const fileSystemUrl = import.meta.env.VITE_FILESYSTEM_URL;
     </div>
     <div class="mb-8">
       <InputFileItemCircularImage
-        :optionalIconIsShown="true"
+        :isShowOptionalIcon="true"
         :src="fileSystemUrl + '/images/icon/default.png'"
         accept="image/jpeg, image/png"
         alt="アイコン"

--- a/src/tests/Js/Molecules/InputFileItemCircularImage.spec.js
+++ b/src/tests/Js/Molecules/InputFileItemCircularImage.spec.js
@@ -116,7 +116,7 @@ describe("InputFileItemCircularImageコンポーネントテスト", () => {
     // キャンセルイベントが発火すると、CircularImageコンポーネントはprops src「storege/test.jpg」を持つこと
     expect(actualSrc).toBe(options.props.src);
   });
-  test("props optionalIconIsShown default false", () => {
+  test("props isShowOptionalIcon default false", () => {
     const options = {
       props: {
         validationName: "test_validationName",
@@ -128,11 +128,11 @@ describe("InputFileItemCircularImageコンポーネントテスト", () => {
     // OptionalIconコンポーネントを表示しないこと
     expect(actualExists).toBeFalsy();
   });
-  test("props optionalIconIsShown true", () => {
+  test("props isShowOptionalIcon true", () => {
     const options = {
       props: {
         validationName: "test_validationName",
-        optionalIconIsShown: true,
+        isShowOptionalIcon: true,
       },
     };
     const wrapper = mount(InputFileItemCircularImage, options);


### PR DESCRIPTION
真偽値props名の命名規則を変更するため。
接頭辞に「is」を付け、「optionalIconIsShown」から「isShowOptionalIcon」に変更する。