### PR TITLE
update:IconNavコンポーネントからLinkタグを外す

### DIFF
--- a/src/resources/js/Molecules/IconNav.vue
+++ b/src/resources/js/Molecules/IconNav.vue
@@ -1,18 +1,13 @@
 <script setup>
-import { Link } from "@inertiajs/vue3";
 
 defineProps({
-  href: {
-    type: String,
-    required: true,
-  },
   nav: String,
 });
 </script>
 
 <template>
-  <Link class="rounded border border-gray-300 bg-white pb-2 pt-4 hover:brightness-90" :href="href">
+  <div class="rounded border border-gray-300 bg-white pb-2 pt-4 hover:brightness-90">
     <slot />
     <span class="mt-2 block text-center">{{ nav }}</span>
-  </Link>
+  </div>
 </template>

--- a/src/resources/js/Organisms/IconNavList.vue
+++ b/src/resources/js/Organisms/IconNavList.vue
@@ -3,18 +3,25 @@ import IconNav from "@/Molecules/IconNav.vue";
 import RankingIcon from "@/Atoms/Icon/RankingIcon.vue";
 import BrandIcon from "@/Atoms/Icon/BrandIcon.vue";
 import CategoryIcon from "@/Atoms/Icon/CategoryIcon.vue";
+import { Link } from "@inertiajs/vue3";
 </script>
 
 <template>
   <nav class="flex">
-    <IconNav class="mr-4 w-1/3" href="" nav="ランキング">
-      <RankingIcon class="mx-auto" />
-    </IconNav>
-    <IconNav class="mr-4 w-1/3" :href="route('categories.index')" nav="カテゴリー">
-      <BrandIcon class="mx-auto" />
-    </IconNav>
-    <IconNav class="w-1/3" :href="route('brands.index')" nav="ブランド">
-      <CategoryIcon class="mx-auto" />
-    </IconNav>
+    <Link href="" class="mr-4 w-1/3">
+      <IconNav nav="ランキング">
+        <RankingIcon class="mx-auto" />
+      </IconNav>
+    </Link>
+    <Link :href="route('categories.index')" class="mr-4 w-1/3">
+      <IconNav nav="カテゴリー">
+        <BrandIcon class="mx-auto" />
+      </IconNav>
+    </Link>
+    <Link :href="route('brands.index')" class="w-1/3">
+      <IconNav nav="ブランド">
+        <CategoryIcon class="mx-auto" />
+      </IconNav>
+    </Link>
   </nav>
 </template>


### PR DESCRIPTION
IconNavコンポーネントはMoleculesに該当するため、Linkタグがあるのは誤ってる。
そのため、Linkタグを親コンポーネントに移動する。