### PR TITLE
remove:IconNavコンポーネントから「props href」のテストコードを削除

### DIFF
--- a/src/tests/Js/Molecules/IconNav.spec.js
+++ b/src/tests/Js/Molecules/IconNav.spec.js
@@ -1,5 +1,4 @@
 import IconNav from "@/Molecules/IconNav.vue";
-import { Link } from "@inertiajs/vue3";
 import { mount } from "@vue/test-utils";
 
 describe("IconNavコンポーネントテスト", () => {
@@ -8,9 +7,6 @@ describe("IconNavコンポーネントテスト", () => {
       slots: {
         default: "test_default",
       },
-      props: {
-        href: "/test_ref",
-      },
     };
     const wrapper = mount(IconNav, options);
     const actualText = wrapper.text();
@@ -18,23 +14,10 @@ describe("IconNavコンポーネントテスト", () => {
     // 「test_default」を表示すること
     expect(actualText).toContain("test_default");
   });
-  test("props href", () => {
-    const options = {
-      props: {
-        href: "/test_ref",
-      },
-    };
-    const wrapper = mount(IconNav, options);
-    const actualHref = wrapper.getComponent(Link).props().href;
-
-    // Linkコンポーネントはprops href「/test_ref」を持つこと
-    expect(actualHref).toBe("/test_ref");
-  });
   test("props nav", () => {
     const options = {
       props: {
         nav: "test_nav",
-        href: "/test_ref",
       },
     };
     const wrapper = mount(IconNav, options);


### PR DESCRIPTION
「props href」を削除済みのため。