### PR TITLE
fix:PHPUnitのテストでエラーが発生する

### DIFF
--- a/src/app/Http/Controllers/ProductController.php
+++ b/src/app/Http/Controllers/ProductController.php
@@ -56,7 +56,7 @@ class ProductController extends Controller
     public function create(): Response
     {
         return Inertia::render('Product/Create', [
-            'brands' => Brand::orderBy('katakana')->get(),
+            'brands' => Brand::orderBy('name_katakana')->get(),
             'categories' => Category::all()
         ]);
     }
@@ -124,7 +124,7 @@ class ProductController extends Controller
 
         return Inertia::render('Product/Edit', [
             'product' => $product,
-            'brands' => Brand::orderBy('katakana')->get(),
+            'brands' => Brand::orderBy('name_katakana')->get(),
             'categories' => Category::all()
         ]);
     }


### PR DESCRIPTION
・原因
ブランドテーブルのkatakanaカラムをname_katakanaに変更したが、katakanaカラムで並び替えする 処理を変更していなかった。

・修正内容
name_katakanaカラムで並び替えするように修正する。

・確認テスト
テストが通ること。

#34