### PR TITLE
update:IconNavコンポーネントのアイコンの位置調整を変更

### DIFF
--- a/src/resources/js/Molecules/IconNav.vue
+++ b/src/resources/js/Molecules/IconNav.vue
@@ -6,7 +6,7 @@ defineProps({
 </script>
 
 <template>
-  <div class="rounded border border-gray-300 bg-white pb-2 pt-4 hover:brightness-90">
+  <div class="flex flex-col items-center rounded border border-gray-300 bg-white pb-2 pt-4 hover:brightness-90">
     <slot />
     <span class="mt-2 block text-center">{{ nav }}</span>
   </div>

--- a/src/resources/js/Organisms/IconNavList.vue
+++ b/src/resources/js/Organisms/IconNavList.vue
@@ -10,17 +10,17 @@ import { Link } from "@inertiajs/vue3";
   <nav class="flex">
     <Link href="" class="mr-4 w-1/3">
       <IconNav nav="ランキング">
-        <RankingIcon class="mx-auto" />
+        <RankingIcon />
       </IconNav>
     </Link>
     <Link :href="route('categories.index')" class="mr-4 w-1/3">
       <IconNav nav="カテゴリー">
-        <BrandIcon class="mx-auto" />
+        <BrandIcon />
       </IconNav>
     </Link>
     <Link :href="route('brands.index')" class="w-1/3">
       <IconNav nav="ブランド">
-        <CategoryIcon class="mx-auto" />
+        <CategoryIcon />
       </IconNav>
     </Link>
   </nav>


### PR DESCRIPTION
IconNavコンポーネント内でアイコンの位置調整をするように変更する。
スロットで挿入するアイコンコンポーネントで位置調整をする必要はない。