### PR TITLE
add:ブランドテーブルにview_countカラムを追加

### DIFF
--- a/src/app/Http/Controllers/BrandController.php
+++ b/src/app/Http/Controllers/BrandController.php
@@ -20,7 +20,7 @@ class BrandController extends Controller
     public function index(): Response
     {
         return Inertia::render('Brand/Index', [
-            'asideBrands' => Brand::orderByRaw('`order` IS NULL ASC')->orderBy('order')->limit(3)->get(),
+            'asideBrands' => Brand::orderBy('view_count', 'desc')->limit(3)->get(),
             'asideCategories' => Category::orderByRaw('`order` IS NULL ASC')->orderBy('order')->limit(3)->get(),
             'brands' => Brand::orderBy('name_katakana')->get(),
         ]);
@@ -35,6 +35,9 @@ class BrandController extends Controller
      */
     public function showProductsByBrand(Brand $brand)
     {
+        $brand->view_count++;
+        $brand->save();
+
         $products = Product::with(['productImages', 'brand', 'category'])
             ->where('brand_id', $brand->id)
             ->selectRaw('*, FORMAT(price_including_tax, 0) as price_including_tax')
@@ -51,7 +54,7 @@ class BrandController extends Controller
             'title' => $brand->name,
             'heading' => $brand->name,
             'products' => $products->getProducts(),
-            'brands' => Brand::orderByRaw('`order` IS NULL ASC')->orderBy('order')->limit(3)->get(),
+            'brands' => Brand::orderBy('view_count', 'desc')->limit(3)->get(),
             'categories' => Category::orderByRaw('`order` IS NULL ASC')->orderBy('order')->limit(3)->get(),
         ]);
     }

--- a/src/app/Http/Controllers/CategoryController.php
+++ b/src/app/Http/Controllers/CategoryController.php
@@ -20,7 +20,7 @@ class CategoryController extends Controller
     public function index(): Response
     {
         return Inertia::render('Category/Index', [
-            'asideBrands' => Brand::orderByRaw('`order` IS NULL ASC')->orderBy('order')->limit(3)->get(),
+            'asideBrands' => Brand::orderBy('view_count', 'desc')->limit(3)->get(),
             'asideCategories' => Category::orderByRaw('`order` IS NULL ASC')->orderBy('order')->limit(3)->get(),
             'categories' => Category::all(),
         ]);
@@ -51,7 +51,7 @@ class CategoryController extends Controller
             'title' => $category->name,
             'heading' => $category->name,
             'products' => $products->getProducts(),
-            'brands' => Brand::orderByRaw('`order` IS NULL ASC')->orderBy('order')->limit(3)->get(),
+            'brands' => Brand::orderBy('view_count', 'desc')->limit(3)->get(),
             'categories' => Category::orderByRaw('`order` IS NULL ASC')->orderBy('order')->limit(3)->get(),
         ]);
     }

--- a/src/app/Http/Controllers/IndexController.php
+++ b/src/app/Http/Controllers/IndexController.php
@@ -35,7 +35,7 @@ class IndexController extends Controller
 
         return Inertia::render('Index', [
             'isIndexPage' => $isIndexPage,
-            'brands' => Brand::orderByRaw('`order` IS NULL ASC')->orderBy('order')->limit(3)->get(),
+            'brands' => Brand::orderBy('view_count', 'desc')->limit(3)->get(),
             'categories' => Category::orderByRaw('`order` IS NULL ASC')->orderBy('order')->limit(3)->get(),
             'heading' => '新着商品',
             'products' => $products->getProducts(),

--- a/src/app/Http/Controllers/SearchController.php
+++ b/src/app/Http/Controllers/SearchController.php
@@ -31,7 +31,7 @@ class SearchController extends Controller
         $products = new Products($products);
 
         return Inertia::render('Index', [
-            'brands' => Brand::orderByRaw('`order` IS NULL ASC')->orderBy('order')->limit(3)->get(),
+            'brands' => Brand::orderBy('view_count', 'desc')->limit(3)->get(),
             'categories' => Category::orderByRaw('`order` IS NULL ASC')->orderBy('order')->limit(3)->get(),
             'heading' => $request->keyword,
             'products' => $products->getProducts()->appends(['keyword' => $request->keyword]),

--- a/src/database/factories/BrandFactory.php
+++ b/src/database/factories/BrandFactory.php
@@ -19,7 +19,6 @@ class BrandFactory extends Factory
         return [
             'name' => fake()->text(50),
             'name_katakana' => fake()->text(50),
-            'order' => fake()->unique()->numberBetween(1, 255)
         ];
     }
 }

--- a/src/database/migrations/2023_10_28_140106_create_brands_table.php
+++ b/src/database/migrations/2023_10_28_140106_create_brands_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->smallIncrements('id');
             $table->string('name', 50)->unique();
             $table->string('name_katakana', 50)->unique();
-            $table->unsignedTinyInteger('order')->unique()->nullable();
+            $table->unsignedMediumInteger('view_count')->default(0);
             $table->timestamps();
         });
     }

--- a/src/database/seeders/BrandsTableSeeder.php
+++ b/src/database/seeders/BrandsTableSeeder.php
@@ -19,21 +19,15 @@ class BrandsTableSeeder extends Seeder
             [
                 'name' => 'アトピタ',
                 'name_katakana' => 'アトピタ',
-                'order' => 1,
             ],
             [
                 'name' => 'アトピコ',
                 'name_katakana' => 'アトピコ',
-                'order' => 2,
             ],
             [
                 'name' => 'キュレル',
                 'name_katakana' => 'キュレル',
-                'order' => 3,
             ],
-        ]);
-
-        DB::table('brands')->insert([
             [
                 'name' => 'ATOPI SMILE',
                 'name_katakana' => 'アトピスマイル',

--- a/src/tests/Feature/BrandTest.php
+++ b/src/tests/Feature/BrandTest.php
@@ -77,4 +77,17 @@ class BrandTest extends TestCase
         $response->assertStatus(302)
             ->assertRedirect('/');
     }
+
+    /**
+     * @access public
+     * @return void
+     */
+    public function test_showProductsByBrand_ブランド別商品閲覧数をインクリメントすること(): void
+    {
+        $brand = Brand::factory()->create();
+
+        $this->get(route('brands.products', ['brand' => $brand->id]));
+
+        $this->assertSame(1, $brand->fresh()->view_count);
+    }
 }


### PR DESCRIPTION
ブランド別商品閲覧数をカウントするため。
閲覧数により、人気ブランドの表示順を決定する。