### PR TITLE
add:カテゴリーテーブルにview_countカラムを追加

### DIFF
--- a/src/app/Http/Controllers/BrandController.php
+++ b/src/app/Http/Controllers/BrandController.php
@@ -21,7 +21,7 @@ class BrandController extends Controller
     {
         return Inertia::render('Brand/Index', [
             'asideBrands' => Brand::orderBy('view_count', 'desc')->limit(3)->get(),
-            'asideCategories' => Category::orderByRaw('`order` IS NULL ASC')->orderBy('order')->limit(3)->get(),
+            'asideCategories' => Category::orderBy('view_count', 'desc')->limit(3)->get(),
             'brands' => Brand::orderBy('name_katakana')->get(),
         ]);
     }
@@ -55,7 +55,7 @@ class BrandController extends Controller
             'heading' => $brand->name,
             'products' => $products->getProducts(),
             'brands' => Brand::orderBy('view_count', 'desc')->limit(3)->get(),
-            'categories' => Category::orderByRaw('`order` IS NULL ASC')->orderBy('order')->limit(3)->get(),
+            'categories' => Category::orderBy('view_count', 'desc')->limit(3)->get(),
         ]);
     }
 }

--- a/src/app/Http/Controllers/IndexController.php
+++ b/src/app/Http/Controllers/IndexController.php
@@ -36,7 +36,7 @@ class IndexController extends Controller
         return Inertia::render('Index', [
             'isIndexPage' => $isIndexPage,
             'brands' => Brand::orderBy('view_count', 'desc')->limit(3)->get(),
-            'categories' => Category::orderByRaw('`order` IS NULL ASC')->orderBy('order')->limit(3)->get(),
+            'categories' => Category::orderBy('view_count', 'desc')->limit(3)->get(),
             'heading' => '新着商品',
             'products' => $products->getProducts(),
             'title' => '敏感肌、アトピー肌向け商品クチコミサイト',

--- a/src/app/Http/Controllers/SearchController.php
+++ b/src/app/Http/Controllers/SearchController.php
@@ -32,7 +32,7 @@ class SearchController extends Controller
 
         return Inertia::render('Index', [
             'brands' => Brand::orderBy('view_count', 'desc')->limit(3)->get(),
-            'categories' => Category::orderByRaw('`order` IS NULL ASC')->orderBy('order')->limit(3)->get(),
+            'categories' => Category::orderBy('view_count', 'desc')->limit(3)->get(),
             'heading' => $request->keyword,
             'products' => $products->getProducts()->appends(['keyword' => $request->keyword]),
             'title' => $request->keyword . 'の商品検索結果',

--- a/src/database/factories/CategoryFactory.php
+++ b/src/database/factories/CategoryFactory.php
@@ -18,7 +18,6 @@ class CategoryFactory extends Factory
     {
         return [
             'name' => fake()->text(20),
-            'order' => fake()->unique()->numberBetween(1, 255)
         ];
     }
 }

--- a/src/database/migrations/2023_10_28_140108_create_categories_table.php
+++ b/src/database/migrations/2023_10_28_140108_create_categories_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
         Schema::create('categories', function (Blueprint $table) {
             $table->tinyIncrements('id');
             $table->string('name', 20)->unique();
-            $table->unsignedTinyInteger('order')->unique()->nullable();
+            $table->unsignedMediumInteger('view_count')->default(0);
             $table->timestamps();
         });
     }

--- a/src/database/seeders/CategoriesTableSeeder.php
+++ b/src/database/seeders/CategoriesTableSeeder.php
@@ -18,19 +18,13 @@ class CategoriesTableSeeder extends Seeder
         DB::table('categories')->insert([
             [
                 'name' => '化粧水',
-                'order' => 1
             ],
             [
                 'name' => '乳液',
-                'order' => 2
             ],
             [
                 'name' => 'オールインワン化粧品',
-                'order' => 3
             ],
-        ]);
-
-        DB::table('categories')->insert([
             [
                 'name' => 'フェイスオイル',
             ],

--- a/src/tests/Feature/CategoryTest.php
+++ b/src/tests/Feature/CategoryTest.php
@@ -77,4 +77,17 @@ class CategoryTest extends TestCase
         $response->assertStatus(302)
             ->assertRedirect('/');
     }
+
+    /**
+     * @access public
+     * @return void
+     */
+    public function test_showProductsByCategory_カテゴリー別商品閲覧数をインクリメントすること(): void
+    {
+        $category = Category::factory()->create();
+
+        $this->get(route('categories.products', ['category' => $category->id]));
+
+        $this->assertSame(1, $category->fresh()->view_count);
+    }
 }


### PR DESCRIPTION
カテゴリー別商品閲覧数をカウントするため。
閲覧数により、人気カテゴリーの表示順を決定する。