### PR TITLE
add:LikeIconコンポーネントのテストを追加、算出プロパティ名を変更

### DIFF
--- a/src/resources/js/Atoms/Icon/LikeIcon.vue
+++ b/src/resources/js/Atoms/Icon/LikeIcon.vue
@@ -12,7 +12,7 @@ const strokeWidth = computed(() => {
   return "1";
 });
 
-const classes = computed(() => {
+const attachedClass = computed(() => {
   if (props.isFull) {
     return "fill-pink-500";
   }
@@ -26,7 +26,7 @@ const classes = computed(() => {
     viewBox="0 0 24 24"
     :stroke-width="strokeWidth"
     stroke="currentColor"
-    :class="classes"
+    :class="attachedClass"
     class="h-6 w-6 inline-block"
   >
     <path stroke-linecap="round" stroke-linejoin="round"

--- a/src/tests/Js/Atoms/Icon/LikeIcon.spec.js
+++ b/src/tests/Js/Atoms/Icon/LikeIcon.spec.js
@@ -1,0 +1,37 @@
+import LikeIcon from "@/Atoms/Icon/LikeIcon.vue";
+import { mount } from "@vue/test-utils";
+
+describe("LikeIconコンポーネントテスト", () => {
+  test("props isFull true", () => {
+    const options = {
+      props: {
+        isFull: true,
+      },
+    };
+    const wrapper = mount(LikeIcon, options);
+
+    // svg要素はclass属性値「fill-pink-500」を持つこと
+    const actualClasses = wrapper.get("svg").classes();
+    expect(actualClasses).toContain("fill-pink-500");
+
+    // svg要素はstroke-width属性値「0」を持つこと
+    const actualStrokeWidth = wrapper.get("svg").attributes("stroke-width");
+    expect(actualStrokeWidth).toBe("0");
+  });
+  test("props isFull false", () => {
+    const options = {
+      props: {
+        isFull: false,
+      },
+    };
+    const wrapper = mount(LikeIcon, options);
+
+    // svg要素はclass属性値「fill-none」を持つこと
+    const actualClasses = wrapper.get("svg").classes();
+    expect(actualClasses).toContain("fill-none");
+
+    // svg要素はstroke-width属性値「1」を持つこと
+    const actualStrokeWidth = wrapper.get("svg").attributes("stroke-width");
+    expect(actualStrokeWidth).toBe("1");
+  });
+});


### PR DESCRIPTION
テストが未実装のため、追加する。
算出プロパティ名が不適切なため、変更する。