### PR TITLE
fix:自動テスト後にデプロイされない

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,5 +92,5 @@ jobs:
           echo "$PRIVATE_KEY" > private_key && chmod 600 private_key
           ssh -o StrictHostKeyChecking=no -i private_key ${USER_NAME}@${HOST_NAME} \
           cd project/atopic-labo && \
-          git pull git@github.com:honda0118/atopic-labo.git && \
+          git pull git@github.com:honda0118/atopic-labo.git main && \
           docker compose exec app npm run build


### PR DESCRIPTION
・原因
mainブランチを指定せずにgit pullコマンドを実行するため、デプロイされない。

・修正内容
mainブランチを指定する。

#75