### PR TITLE
fix:自動テスト後にデプロイされない

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,5 +92,5 @@ jobs:
           echo "$PRIVATE_KEY" > private_key && chmod 600 private_key
           ssh -o StrictHostKeyChecking=no -i private_key ${USER_NAME}@${HOST_NAME} \
           cd project/atopic-labo && \
-          git pull git@github.com:honda0118/atopic-labo.git main && \
+          git pull origin main && \
           docker compose exec app npm run build


### PR DESCRIPTION
#75の追加修正。

・原因
下記コマンドだとエラーになり、デプロイされない。
git pull git@github.com:honda0118/atopic-labo.git main

エラーログ
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

「git@github.com:honda0118/atopic-labo.git」をリポジトリとして認識されないようだ。

・修正内容
「git@github.com:honda0118/atopic-labo.git」を「origin」に修正する。

#75