### PR TITLE
fix:自動テスト後にデプロイされない

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,6 +91,6 @@ jobs:
         run: |
           echo "$PRIVATE_KEY" > private_key && chmod 600 private_key
           ssh -o StrictHostKeyChecking=no -i private_key ${USER_NAME}@${HOST_NAME} \
-          cd project/atopic-labo && \
+          "cd project/atopic-labo && \
           git pull origin main && \
-          docker compose exec app npm run build
+          docker compose exec app npm run build"


### PR DESCRIPTION
#75の追加修正。

・原因
下記コマンドだとエラーになり、デプロイされない。
cd project/atopic-labo && \
git pull origin main && \
docker compose exec app npm run build

エラーログ
service "app" is not running

・修正内容
コマンドにダブルクォーテーションを付ける。

#75