### PR TITLE
fix:本番環境でページネーションが機能しない

### DIFF
--- a/src/app/Providers/AppServiceProvider.php
+++ b/src/app/Providers/AppServiceProvider.php
@@ -26,6 +26,7 @@ class AppServiceProvider extends ServiceProvider
     {
         if (config('app.env') !== 'local') {
             URL::forceScheme('https');
+            $this->app['request']->server->set('HTTPS', 'on');
         }
     }
 }


### PR DESCRIPTION
・原因
ページネーションが生成するリンクがHTTPSではなく、HTTPになっているため。
本番環境はHTTPSに対応する。

・修正内容
HTTPSのリンクを生成するように修正する。

・確認テスト
HTTPSのリンクを生成すること。

#81