### PR TITLE
update:ListItemChevronRightIconコンポーネントのhoverをbrightness-90に変更

### DIFF
--- a/src/resources/js/Molecules/ListItemChevronRightIcon.vue
+++ b/src/resources/js/Molecules/ListItemChevronRightIcon.vue
@@ -21,7 +21,7 @@ const classes = computed(() => {
 <template>
   <li
     :class="classes"
-    class="flex items-center justify-between border-b border-gray-300 pl-2 hover:bg-gray-100"
+    class="flex items-center justify-between border-b border-gray-300 pl-2 bg-white hover:brightness-90"
   >
     {{ nav }}
     <ChevronRightIcon />


### PR DESCRIPTION
bg-gray-100にしていたが、brightness-90のほうが適切なため。
本プロジェクトではhoverの明度調整をbrightness-90に統一している。